### PR TITLE
[BUG-FIX] Variable name bug

### DIFF
--- a/core/rule.py
+++ b/core/rule.py
@@ -135,9 +135,9 @@ def match_entity(entity, cond):
             bresult.append(__prop_query(entity.props[p], cond['any']))
         return op_or(bresult)
     
-    for p in cond.keys():
-        if p in entity.props.keys():
-            bresult.append(__prop_query(entity.props[p], cond[p]))
+    for c_p in cond.keys():
+        if e_p in entity.props.keys():
+            bresult.append(__prop_query(entity.props[e_p], cond[c_p]))
     return op_and(bresult)
 
 # 默认 op 是 or


### PR DESCRIPTION
In match_entity(), looping 2 for loop, p variable is used for cond and props's key.
Same p variable is used for 2 different dict, resulting omitting first for loop's iterator value.
Changed variables' name to e_p and c_p for entity property, condition property.


edit:
Sorry for this. I miss read some code.
There's no such bug. Closing request...